### PR TITLE
Dont show variables

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -137,5 +137,8 @@ The above system shows that `Engineers` has an initial value of `Managers * 4`,
 a maximum value of `Managers * 8` and then shows that both `Engineers` and `Managers`
 grow at multiples of the value of the `Recruiters` stock.
 
-This is also a good example of using the `Recruiters` stock as
-a variable, as it doesn't' actually change over time.
+This is also a good example of using the `Recruiters` stock as a
+variable, as it doesn't actually change over time. (Although note that
+this pattern can only be used for constants: if you specify a formula
+that will only be used for the initial value, which is probably not
+what you want.)

--- a/systems/viz.py
+++ b/systems/viz.py
@@ -10,18 +10,24 @@ from .errors import ParseException
 
 
 def as_dot(model, rankdir="LR"):
-    mapping = {s.name: str(i) for i, s in enumerate(model.stocks)}    
+    mapping = {s.name: str(i) for i, s in enumerate(model.stocks)}
     dot = Digraph(comment=model.name)
     dot.attr(rankdir=rankdir)
-    
-    for stock in model.stocks:
-        dot.node(mapping[stock.name], stock.name)
+
+    nodes_in_flow = set()
 
     for flow in model.flows:
         source_id = mapping[flow.source.name]
         destination_id = mapping[flow.destination.name]
+        nodes_in_flow.add(source_id)
+        nodes_in_flow.add(destination_id)
 
         dot.edge(source_id, destination_id)
+
+    for stock in model.stocks:
+        node_id = mapping[stock.name]
+        if node_id in nodes_in_flow:
+            dot.node(node_id, stock.name)
 
     return dot
 


### PR DESCRIPTION
This is more speculative than my other PR -- since I'm discarding information I could imagine you might not like it. I'd be happy to add a command line flag to trigger this behaviour if you prefer, but my feeling is that it's so likely to be the right thing to do that there's no need to bother the user with it.

As you can probably tell, I found myself making heavy use of "variables" in my modelling.