### PR TITLE
Catch missing parens

### DIFF
--- a/systems/errors.py
+++ b/systems/errors.py
@@ -47,6 +47,10 @@ class FormulaError(IllegalSystemException):
         return "%s for formula '%s'" % (self.__class__.__name__, self.formula)
 
 
+class MismatchedParens(FormulaError):
+    pass
+
+
 class CircularReferences(IllegalSystemException):
     def __init__(self, cycle, graph):
         self.cycle = cycle

--- a/systems/lexer.py
+++ b/systems/lexer.py
@@ -67,7 +67,13 @@ def lex_formula(txt):
             prev_tokens = groups.pop()
             prev_tokens.append((TOKEN_FORMULA, tokens))
             tokens = prev_tokens
-        elif c in (WHITESPACE, NEWLINE):
+        elif c == WHITESPACE:
+            if acc:
+                tokens.append(lex_value(acc))
+            acc = ""
+        elif c == NEWLINE:
+            if groups:
+                raise systems.errors.MismatchedParens(txt)
             if acc:
                 tokens.append(lex_value(acc))
             acc = ""

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -128,6 +128,16 @@ class TestParse(unittest.TestCase):
         self.assertEqual(7.5, final['C'])
         self.assertEqual(40, final['D'])
 
+    def test_missing_parens(self):
+        "There is a missing paren in the rate definition"
+        txt = """
+        [A]
+        A > B @ Rate(1 * (1 + (1 * 1))
+        """
+        with self.assertRaises(systems.errors.MismatchedParens):
+            m = parse.parse(txt)
+            results = m.run()
+
     def test_conflicting_stock_values(self):
         txt = """
         a(10) > b @ 1

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -51,7 +51,7 @@ class TestParse(unittest.TestCase):
 
         names = ['Hires', 'Developers', 'Ideas', 'Projects', 'Started', 'Finished']
         for name in names:
-            self.assertEquals(name, model.get_stock(name).name)
+            self.assertEqual(name, model.get_stock(name).name)
 
         results = model.run(rounds=10)
         for row in results:


### PR DESCRIPTION
Not sure that I'm holding the error hierarchy right. I tried to use the fancy `DeferLineInfo` stuff, but I couldn't make that work at this point in the parser.

So the error that this produces isn't particularly user-friendly.

This line (missing a terminal paren):

```
Ideas > Options @ Rate(IdentificationR * (PMs - (PMDeliveryBurden * Deliverables))
```

Gives this error:

```
$ cat error.sys | systems-run
Traceback (most recent call last):
  File "/home/benbc/.pyenv/versions/3.10.5/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/benbc/.pyenv/versions/3.10.5/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/benbc/src/lethain/systems/systems/parse.py", line 143, in <module>
    main()
  File "/home/benbc/src/lethain/systems/systems/parse.py", line 129, in main
    model = parse(txt)
  File "/home/benbc/src/lethain/systems/systems/parse.py", line 86, in parse
    _, tokens = lexer.lex(txt)
  File "/home/benbc/src/lethain/systems/systems/lexer.py", line 179, in lex
    line.append(lex_flow(char_buff))
  File "/home/benbc/src/lethain/systems/systems/lexer.py", line 134, in lex_flow
    return lex_caller(TOKEN_FLOW, txt)
  File "/home/benbc/src/lethain/systems/systems/lexer.py", line 113, in lex_caller
    params = lex_parameters(rest)
  File "/home/benbc/src/lethain/systems/systems/lexer.py", line 97, in lex_parameters
    return (TOKEN_PARAMS, tuple([lex_formula(x) for x in params]))
  File "/home/benbc/src/lethain/systems/systems/lexer.py", line 97, in <listcomp>
    return (TOKEN_PARAMS, tuple([lex_formula(x) for x in params]))
  File "/home/benbc/src/lethain/systems/systems/lexer.py", line 76, in lex_formula
    raise systems.errors.MismatchedParens(txt)
systems.errors.MismatchedParens: MismatchedParens for formula 'IdentificationR*(PMs-(PMDeliveryBurden*Deliverables)'
```